### PR TITLE
Feat: handle outside of range strike

### DIFF
--- a/src/lib/StrikePriceGenerator.sol
+++ b/src/lib/StrikePriceGenerator.sol
@@ -38,6 +38,7 @@ library StrikePriceGenerator {
    * @param maxNumStrikes A cap on how many strikes can be in a single board.
    * @param liveStrikes Array of strikes that already exist in the board, will avoid generating them.
    * @return newStrikes The additional strikes that must be added to the board.
+   * @return numAdded Total number of added strikes as `newStrikes` may contain blank entries.
    */
   function getNewStrikes(
     uint tTarget,
@@ -168,6 +169,7 @@ library StrikePriceGenerator {
    * @param minStrike Min allowed strike based on moneyness (delta).
    * @param maxStrike Max allowed strike based on moneyness (delta).
    * @return newStrikes Additional strikes to add.
+   * @return numAdded Total number of added strikes as `newStrikes` may contain blank entries.
    */
   function _createNewStrikes(
     uint[] memory liveStrikes,

--- a/test/lib/StrikePriceGeneratorTest.t.sol
+++ b/test/lib/StrikePriceGeneratorTest.t.sol
@@ -69,7 +69,8 @@ contract StrikePriceGeneratorTest is Test {
     liveStrikes[1] = 1025e18;
     liveStrikes[2] = 1050e18;
 
-    (uint[] memory newStrikes, uint numAdded) = tester.getNewStrikes(_secToAnnualized(2 weeks), 1000e18, 120e16, 3, liveStrikes);
+    (uint[] memory newStrikes, uint numAdded) =
+      tester.getNewStrikes(_secToAnnualized(2 weeks), 1000e18, 120e16, 3, liveStrikes);
 
     assertEq(newStrikes.length, 0);
     assertEq(numAdded, 0);
@@ -151,7 +152,6 @@ contract StrikePriceGeneratorTest is Test {
 
     assertEq(tester.getLeftNearestPivot(1550e18), 1000e18);
   }
-
 
   function testStopsAddingOnceOutsideRange() public {
     // 2 week expiry setup


### PR DESCRIPTION
## Summary

One bug in StrikePriceGenerator Library:
- When max number of strikes isn't reached but the new strikes are all beyond the moneyness range, need to early return, otherwise stuck in an infinite loop.

One side-effects:
- Because of the early return, the newStrikes[] array may come back empty. So adding a second return variable `numAdded` so that contracts can easily know how many strikes are added. 
- If the above isn't used, you will end up calling VolGenerator with strikePrice = 0, at which point the moneyness() helper will revert.

## Details

Any implementation detail worth pointing out, if any.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Add [natspec](https://docs.soliditylang.org/en/latest/natspec-format.html) for all functions / parameters
- [x] Ran `forge snapshot`
- [x] Ran `forge fmt`
- [x] Ran `forge test`
- [x] 100% test coverage on code changes